### PR TITLE
Herd Unit Testing Fixes

### DIFF
--- a/mcomp-Java/src/common/Herd.java
+++ b/mcomp-Java/src/common/Herd.java
@@ -69,7 +69,7 @@ public class Herd {
 		//election
 		theLeader = a;
 	}
-	
+
 	/*
 	 * The nomination process. The Leader variable is populated
 	 * by the Member Object of the Leader.
@@ -79,8 +79,8 @@ public class Herd {
 		theLeader = herdMembers.get(0);
 		return theLeader;
 	}
-	
-	
+
+
 	/*
 	 * This is where requests to join the Herd are handled. In the
 	 * full implementation, a Herd can only be "merged" with another,
@@ -113,15 +113,17 @@ public class Herd {
 				break;
 			case "DestSetter":
 				//TODO Need code to check the old destSetter and remove it if it only has the one ability.
-				herdDestSetters.getAbilities().remove("W");
-				herdDestSetters.leaveHerd(this);
+				if(herdDestSetters != null) {
+					herdDestSetters.getAbilities().remove("W");
+				}
+				//herdDestSetters.leaveHerd(this);
 				herdDestSetters = aspiringMember;
 				break;
 			}
 		}
 		return herdMembers;
 	}
-	
+
 	/*
 	 * This where requests to leave the Herd are handled. In order to leave,
 	 * a member must removed from the Herds lists of specialists. All remaining
@@ -164,28 +166,28 @@ public class Herd {
 			}
 		}
 		if(theLeader.getPublicKey().equals(leavingMember.getPublicKey())){
-		   nominateLeader();
+			nominateLeader();
 		}
 		return herdMembers;
 	}
-	
-//	public ArrayList<String> publishMembers() {
-//		for(String a: herdMembers){
-//		//TODO for each member in the herdMembers list publish the new list to them
-//		}
-//	}
-	
+
+	//	public ArrayList<String> publishMembers() {
+	//		for(String a: herdMembers){
+	//		//TODO for each member in the herdMembers list publish the new list to them
+	//		}
+	//	}
+
 	public String getHerdID () {
 		return herdID;
 	}
-	
+
 	/*
 	 * Retrieve the list of all Members of the Herd
 	 */
 	public ArrayList<Member> getMembers(){
 		return herdMembers;
 	}
-	
+
 	/*
 	 * Retrieve a single member from the List
 	 */
@@ -197,23 +199,23 @@ public class Herd {
 		}
 		return null;
 	}
-	
+
 	public ArrayList<Member> getDrivers() {
 		return herdDrivers;
 	}
-	
+
 	public ArrayList<Member> getProcessors(){
 		return herdProcessors;
 	}
-	
+
 	public ArrayList<Member> getSensors(){
 		return herdSensors;
 	}
-	
+
 	public ArrayList<Member> getViewers(){
 		return herdViewers;
 	}
-	
+
 	public Member getDestSetter(){
 		return herdDestSetters;
 	}

--- a/mcomp-Java/src/common/Herd.java
+++ b/mcomp-Java/src/common/Herd.java
@@ -137,6 +137,7 @@ public class Herd {
 	 * A debate needs to be about transferring leadership, and what gets copied over.
 	 */
 	public ArrayList<Member> requestLeave(Member leavingMember){
+		herdMembers.remove(leavingMember);
 		for(String b : leavingMember.getAbilities()) {
 			switch (b) {
 			case "Driver":

--- a/mcomp-Java/src/common/Herd.java
+++ b/mcomp-Java/src/common/Herd.java
@@ -114,9 +114,13 @@ public class Herd {
 			case "DestSetter":
 				//TODO Need code to check the old destSetter and remove it if it only has the one ability.
 				if(herdDestSetters != null) {
-					herdDestSetters.getAbilities().remove("W");
+					if(herdDestSetters.getAbilities().size() > 1) {
+						herdDestSetters.getAbilities().remove("W");
+					}
+					else {
+						herdDestSetters.leaveHerd(this);
+					}
 				}
-				//herdDestSetters.leaveHerd(this);
 				herdDestSetters = aspiringMember;
 				break;
 			}
@@ -133,40 +137,24 @@ public class Herd {
 	 * A debate needs to be about transferring leadership, and what gets copied over.
 	 */
 	public ArrayList<Member> requestLeave(Member leavingMember){
-		//TODO There is 100% a smarter way to remove a member from the lists
-		String leaver = leavingMember.getPublicKey();
-		for(Member a: herdMembers) {
-			if(a.getPublicKey().equals(leaver)) {
-				herdMembers.remove(leavingMember);
-			}
-		}
-		for(Member a: herdDrivers) {
-			if(a.getPublicKey().equals(leaver)) {
+		for(String b : leavingMember.getAbilities()) {
+			switch (b) {
+			case "Driver":
 				herdDrivers.remove(leavingMember);
-			}
-		}
-		for(Member a: herdSensors) {
-			if(a.getPublicKey().equals(leaver)) {
-				herdSensors.remove(leavingMember);
-			}
-		}
-		for(Member a: herdProcessors) {
-			if(a.getPublicKey().equals(leaver)) {
-				herdProcessors.remove(leavingMember);
-			}
-		}
-		for(Member a: herdViewers) {
-			if(a.getPublicKey().equals(leaver)) {
-				herdViewers.remove(leavingMember);
-			}
-		}
-		if(herdDestSetters != null) {
-			if (herdDestSetters.getPublicKey().equals(leaver)) {
+				break;
+			case "Processor":
+				herdProcessors.add(leavingMember);
+				break;
+			case "Sensor":
+				herdSensors.add(leavingMember);
+				break;
+			case "Viewer":
+				herdViewers.add(leavingMember);
+				break;
+			case "DestSetter":
 				herdDestSetters = null;
+				break;
 			}
-		}
-		if(theLeader.getPublicKey().equals(leavingMember.getPublicKey())){
-			nominateLeader();
 		}
 		return herdMembers;
 	}

--- a/mcomp-Java/src/common/Herd.java
+++ b/mcomp-Java/src/common/Herd.java
@@ -115,7 +115,7 @@ public class Herd {
 				//TODO Need code to check the old destSetter and remove it if it only has the one ability.
 				if(herdDestSetters != null) {
 					if(herdDestSetters.getAbilities().size() > 1) {
-						herdDestSetters.getAbilities().remove("W");
+						herdDestSetters.getAbilities().remove("DestSetter");
 					}
 					else {
 						herdDestSetters.leaveHerd(this);

--- a/mcomp-Java/src/unitTesting/HerdTesting.java
+++ b/mcomp-Java/src/unitTesting/HerdTesting.java
@@ -57,6 +57,7 @@ public class HerdTesting {
 		}
 		String [] abil3 = {"DestSetter"};
 		members.add(new Member(abil3));
+		members.add(new Member(abil3));
 		for (Member a: members) {
 			a.joinHerd(theHerd);
 		}

--- a/mcomp-Java/src/unitTesting/HerdTesting.java
+++ b/mcomp-Java/src/unitTesting/HerdTesting.java
@@ -36,7 +36,7 @@ public class HerdTesting {
 	
 	@Test
 	/*
-	 * Need to change the type of Array that passes values to 
+	 * Tests the addition of multiple regular Members 
 	 */
 	public void addManyMembers() {
 		String [] arr = {"Driver", "Processor"};
@@ -45,40 +45,26 @@ public class HerdTesting {
 		ArrayList <Member> members = new ArrayList<Member>();
 		for (int i = 0; i < 5; i++) {
 			String [] abil = {"Driver", "Processor", "Sensor"};
-			//TODO Fix the below function to produce various abilities for a Member
-/*			switch (i) {
-			case 0:
-				abil [0] = "D";
-				break;
-			case 1:
-				abil[0] = "D";
-				abil[1] = "P";
-				abil[2] = "S";
-				break;
-			case 2:
-				abil[0] = "V";
-				break;
-			case 3:
-				abil[0] = "V";
-				abil[1] = "W";
-				break;
-			case 4:
-				abil[0] = "D";
-				abil[1] = "P";
-				abil[2] = "S";
-				abil[3] = "V";
-				abil[4] = "W";
-				break;
-			}*/
 			for (int j = 0; j < 10; j++) {
 				members.add(new Member(abil));
 			}
 		}
+		for (int i = 0; i < 5; i++) {
+			String [] abil2 = {"Viewer"};
+			for (int j = 0; j < 10; j++) {
+				members.add(new Member(abil2));
+			}
+		}
+		String [] abil3 = {"DestSetter"};
+		members.add(new Member(abil3));
 		for (Member a: members) {
 			a.joinHerd(theHerd);
 		}
-		System.out.println(theHerd.getMembers().size());
-		assert(theHerd.getMembers().size() == 51);
+		
+		assert(theHerd.getMembers().size() == 102);
+		assert(theHerd.getDrivers().size() == 51);
+		assert(theHerd.getSensors().size() == 50);
+		assert(theHerd.getViewers().size() == 50);
 	}
 	
 	

--- a/mcomp-Java/src/unitTesting/HerdTesting.java
+++ b/mcomp-Java/src/unitTesting/HerdTesting.java
@@ -1,7 +1,6 @@
 package unitTesting;
-import org.junit.*;
-import static org.junit.Assert.*;
-
+import org.junit.Before;
+import org.junit.Test;
 import java.util.ArrayList;
 
 import common.Herd;


### PR DESCRIPTION
I have added the following:

- Fixes for adding more than one destination setter. We previously discussed that although multiple views may exist, one member should be responsible for setting the destination of the Herd. Current behaviour is that the newest added Member with the DestSetter ability is the destination setter.

- Fixed behaviour when a member tries to leave a herd. This was discovered during unit testing.

- Removed the * imports according to the Google style guide.

- Removed redundant static Assert import.
