### PR TITLE
Inet address publishing

### DIFF
--- a/mcomp_Java/src/common/interfaces/Leadable.java
+++ b/mcomp_Java/src/common/interfaces/Leadable.java
@@ -3,9 +3,11 @@
  */
 package common.interfaces;
 
+import java.net.InetAddress;
+
 /**
  * @author David Avery
- *
+ * @author Stephen Pope 15836791
  */
 public interface Leadable {
 
@@ -13,8 +15,9 @@ public interface Leadable {
    * 
    */
   //pass in first bot?? member?? self??
-  // TODO Auto-generated constructor stub
   //Data type?? array?? array list?? queue?? (q means leader = first in / oldest member??)
-  Membership nominateLeader();  
+  Membership nominateLeader();
+  InetAddress [] getAddress();
+  InetAddress publishAddress();
   
 }

--- a/mcomp_Java/src/common/interfaces/Leadable.java
+++ b/mcomp_Java/src/common/interfaces/Leadable.java
@@ -15,6 +15,7 @@ public interface Leadable {
    * 
    */
   //pass in first bot?? member?? self??
+  //IP Address publishing added
   //Data type?? array?? array list?? queue?? (q means leader = first in / oldest member??)
   Membership nominateLeader();
   InetAddress [] getAddress();

--- a/mcomp_Java/src/common/objects/Leader.java
+++ b/mcomp_Java/src/common/objects/Leader.java
@@ -1,0 +1,43 @@
+package common.objects;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import common.interfaces.Leadable;
+import common.interfaces.Membership;
+
+public class Leader implements Leadable {
+	InetAddress[] addresses;
+	InetAddress loopback = InetAddress.getLoopbackAddress();
+
+	@Override
+	public Membership nominateLeader() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	/**
+	 * Polls the host of the Leader and collects the IP address of all 
+	 * reachable interfaces. If an address cannot be reached, return 
+	 * the loopback address.
+	 * 
+	 * @return The array of IP addresses
+	 */
+	@Override
+	public InetAddress[] getAddress() {
+		try {
+			addresses = InetAddress.getAllByName(InetAddress.getLocalHost().getHostName());
+		} catch (UnknownHostException e) {
+			e.printStackTrace();
+			addresses[0] = loopback; 
+		}
+		return addresses;
+	}
+
+	@Override
+	public InetAddress publishAddress() {
+		// TODO For each member in Herd, RMI the address to each Member
+		return null;
+	}
+
+}


### PR DESCRIPTION
As discussed in #73, I have added a Leader Object and methods to get the IP addresses of the host in the Leadable interface. A leader must always be able to distribute its address. Once we decide properly on the structure of the program we can flesh out the code.

This is all alpha code with a few TODO comments and there is room in M2 to refine this code.

