### PR TITLE
Certificate Generation

### DIFF
--- a/mcomp_Scratchpad/src/security/Certificate.java
+++ b/mcomp_Scratchpad/src/security/Certificate.java
@@ -1,0 +1,22 @@
+package security;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+public class Certificate {
+	private KeyPairGenerator keyFactory;
+	private KeyPair leaderKey;
+	
+	private Certificate() {
+		leaderKey = keyFactory.generateKeyPair();
+	}
+	
+	public Certificate getInstance() {
+		if(leaderKey == null) {
+			return new Certificate();
+		}
+		else return this;
+		
+	}
+
+}

--- a/mcomp_Scratchpad/src/security/Certificate.java
+++ b/mcomp_Scratchpad/src/security/Certificate.java
@@ -2,21 +2,28 @@ package security;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 
 public class Certificate {
+	private static Certificate theCert = new Certificate();
 	private KeyPairGenerator keyFactory;
-	private KeyPair leaderKey;
-	
+	private KeyPair leaderPair;
+	private PublicKey publicKey;
+	private PrivateKey privateKey;
+
 	private Certificate() {
-		leaderKey = keyFactory.generateKeyPair();
+		leaderPair = keyFactory.generateKeyPair();
+		publicKey = leaderPair.getPublic();
+		privateKey = leaderPair.getPrivate();
 	}
-	
-	public Certificate getInstance() {
-		if(leaderKey == null) {
-			return new Certificate();
-		}
-		else return this;
-		
+
+	public static Certificate getInstance() {
+		return theCert;
+	}
+
+	public PublicKey getPublicKey() {
+		return publicKey;		
 	}
 
 }

--- a/mcomp_Scratchpad/src/security/Certificate.java
+++ b/mcomp_Scratchpad/src/security/Certificate.java
@@ -5,23 +5,53 @@ import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 
+/**
+ * A class to generate and store a Public/Private Key pairing in
+ * the Java Keystore. Used by the Leader of a Herd to encrypt
+ * communication between itself and the Herd member.
+ * 
+ * This class may well merge with the Leader object, depending
+ * on SOLID principles application.
+ * 
+ * @author Stephen Pope 15836791
+ *
+ */
+
 public class Certificate {
 	private static Certificate theCert = new Certificate();
 	private KeyPairGenerator keyFactory;
 	private KeyPair leaderPair;
 	private PublicKey publicKey;
 	private PrivateKey privateKey;
-
+	
+	/**
+	 * The Certificate Constructor.
+	 * 
+	 * This class implements the Singleton Pattern from the GoF.
+	 * As such, the constructor is private to prevent multiple
+	 * certificates being generated.
+	 */
 	private Certificate() {
 		leaderPair = keyFactory.generateKeyPair();
 		publicKey = leaderPair.getPublic();
 		privateKey = leaderPair.getPrivate();
 	}
-
+	
+	/**
+	 * Get the created instance of the certificate.
+	 * 
+	 * @return The Certificate containing the Public/Private KeyPair.
+	 */
 	public static Certificate getInstance() {
 		return theCert;
 	}
 
+	/**
+	 * Retrieve the Public Key from the certificate, so that it may
+	 * be handed to Members of the Herd by the Leader.
+	 * 
+	 * @return The Public Key
+	 */
 	public PublicKey getPublicKey() {
 		return publicKey;		
 	}


### PR DESCRIPTION
As specified in #64, the Leader of a Herd must be able to generate a certificate in order to encrypt map data sent out to members of the Herd.

My research has led me to the inbuilt Java security libraries. I went for these over using the OS certificates in the end as it keeps our program platform independent. The leader could in theory be any JVM compliant system.

This pull is in the scratch as I am not sure where we are placing leader/security in relation to each other.

I implemented the Singleton Pattern (GoF) in order to ensure that only one instance of the certificate can be created. We don't want self signed certificates just floating about the place!

This is alpha code, so it can be used to create a certificate and retrieve the public key. The next stage is to plug this into our Leader and RMI to distribute to all the members.
